### PR TITLE
Fix duplicate keys

### DIFF
--- a/botocore/data/route53domains/2014-05-15/service-2.json
+++ b/botocore/data/route53domains/2014-05-15/service-2.json
@@ -10,7 +10,6 @@
     "targetPrefix":"Route53Domains_v20140515",
     "uid":"route53domains-2014-05-15"
   },
-  "documentation":"<fullname>Amazon Route 53 Domains</fullname><p>Amazon Route 53 permits Interned Domain Name registration, trasnfer and management</p>",
   "operations":{
     "CheckDomainAvailability":{
       "name":"CheckDomainAvailability",

--- a/botocore/data/sqs/2012-11-05/service-2.json
+++ b/botocore/data/sqs/2012-11-05/service-2.json
@@ -340,27 +340,6 @@
         "ApproximateFirstReceiveTimestamp"
       ]
     },
-    "QueueAttributeMap":{
-      "type":"map",
-      "key":{
-        "shape":"QueueAttributeName",
-        "locationName":"Name"
-      },
-      "value":{
-        "shape":"String",
-        "locationName":"Value"
-      },
-      "flattened":true,
-      "locationName":"Attribute"
-    },
-    "QueueAttributeNameList":{
-      "type":"list",
-      "member":{
-        "shape":"QueueAttributeName",
-        "locationName":"AttributeName"
-      },
-      "flattened":true
-    },
     "BatchEntryIdsNotDistinct":{
       "type":"structure",
       "members":{


### PR DESCRIPTION
Missing keys have been added in the fork and then later upstream in a way that doesn't conflict.
Recent versions of Cpanel::JSON::XS reject duplicate keys by default, breaking `make gen-classes`.