### PR TITLE
Removed duplicate keys with placeholder data

### DIFF
--- a/botocore/data/medialive/2017-10-14/service-2.json
+++ b/botocore/data/medialive/2017-10-14/service-2.json
@@ -2443,16 +2443,6 @@
       },
       "documentation": "Placeholder documentation for CreateInput"
     },
-    "CreateInputResponse": {
-      "type": "structure",
-      "members": {
-        "Input": {
-          "shape": "Input",
-          "locationName": "input"
-        }
-      },
-      "documentation": "Placeholder documentation for CreateInputResponse"
-    },
     "CreateInputResultModel": {
       "type": "structure",
       "members": {
@@ -7524,16 +7514,6 @@
       "required": [
         "ChannelId"
       ]
-    },
-    "UpdateChannelResponse": {
-      "type": "structure",
-      "members": {
-        "Channel": {
-          "shape": "Channel",
-          "locationName": "channel"
-        }
-      },
-      "documentation": "Placeholder documentation for UpdateChannelResponse"
     },
     "UpdateChannelResultModel": {
       "type": "structure",


### PR DESCRIPTION
There was placeholder data left inside which made duplicate keys, which as specified by [RFC 7159](https://tools.ietf.org/html/rfc7159#section-4) is heavily discouraged. The Paws JSON parser unless set as relaxed will not accept them as [seen here](https://metacpan.org/pod/Cpanel::JSON::XS#$enabled-=-$json-%3Eget_relaxed). Either way, it is widely considered "invalid" JSON and therefore amended.